### PR TITLE
Fix bug that label filters and issues don't initially load.

### DIFF
--- a/js/aggregator.js
+++ b/js/aggregator.js
@@ -70,8 +70,8 @@ function GithubIssuesAggregator(){
                                                'issues': allIssues
                                               };
 
-                                callback(finalIssues);
-                                return;
+                                return callback(finalIssues);
+                                
                             }
                         })
                 })(i)

--- a/js/main.js
+++ b/js/main.js
@@ -205,30 +205,33 @@ dashboardApp.controller('MarketplaceController', function ($scope, $http) {
 
   }
 });
+
 dashboardApp.controller('IssuesController', function ($scope, $http, filterFilter) {
 
   $scope.init = function () {
     $("#nav-issues").addClass('active');
     var aggregator = new GithubIssuesAggregator();
+
+    $scope.issueFilters = {'hasPullRequest': '', 'hasAssignee': ''};
+
+    var labelArray = ['Community', 'blocked',
+      'difficulty beginner', 'difficulty intermediate', 'difficulty advanced',
+      'priority low', 'priority medium', 'priority high']
+    $scope.labels = labelArray.map(function (label) {
+      return {'name': label, selected: false}
+    });
+
+    // selected labels
+    $scope.selection = [];
+
+    // helper method
+    $scope.selectedLabels = function selectedLabels() {
+      return filterFilter($scope.labels, { selected: true });
+    };
+
     aggregator.processIssues(function (data) {
       $scope.issues = data.issues;
       $scope.last_updated = data.last_updated;
-      $scope.issueFilters = {'hasPullRequest': ''};
-
-      var labelArray = ['Community', 'blocked',
-        'difficulty beginner', 'difficulty intermediate', 'difficulty advanced',
-        'priority low', 'priority medium', 'priority high']
-      $scope.labels = labelArray.map(function (label) {
-        return {'name': label, selected: false}
-      });
-
-      // selected labels
-      $scope.selection = [];
-
-      // helper method
-      $scope.selectedLabels = function selectedLabels() {
-        return filterFilter($scope.labels, { selected: true });
-      };
 
       // watch labels for changes
       $scope.$watch('labels|filter:{selected:true}', function (nv) {
@@ -246,6 +249,7 @@ dashboardApp.controller('IssuesController', function ($scope, $http, filterFilte
         });
       });
       setTimeout(Hyphenator.run, 200);
+      $scope.$apply();
     });
 
   }
@@ -279,8 +283,10 @@ dashboardApp.controller('IssuesController', function ($scope, $http, filterFilte
           issue.shouldShow = issue.shouldShow && showForLabels;
         }
         var showForAssignee = true;
-        if (issue.shouldShow && $scope.hasAssignee != 'undefined' && $scope.hasAssignee != null | $scope.hasAssignee == '' ) {
-          showForAssignee = (issue.assignee.name && $scope.hasAssignee == 'yes') | (!issue.assignee.name && $scope.hasAssignee == 'no');
+        if (issue.shouldShow && $scope.hasAssignee != 'undefined' && $scope.hasAssignee != null | $scope.hasAssignee == '') {
+          showForAssignee = $scope.hasAssignee == ''
+                            | (issue.assignee.name && $scope.hasAssignee == 'yes')
+                            | (!issue.assignee.name && $scope.hasAssignee == 'no');
           issue.shouldShow = issue.shouldShow && showForAssignee;
         }
       }

--- a/templates/issues.html
+++ b/templates/issues.html
@@ -42,7 +42,7 @@
                     <tbody>
                         <tr ng-repeat="issue in repo.issues" ng-show="issue.shouldShow">
                             <td>
-                                <span ng-if="issue.pull_request.length" class="label label-pull-request">
+                                <span ng-if="issue.pull_request" class="label label-pull-request">
                                     Pull Request
                                 </span>
                                 <span class="hyphenate">


### PR DESCRIPTION
A continuation from #26 and #19.
This also fixed that pull request labels weren't showing as well as some logic with the 'All' filter for 'Assignees'.
Some of the initialization that didn't require the ajax data was moved outside of the callback.
