### PR TITLE
Remove use of GitHub read-only token

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,5 @@
     "https://github.com/mozilla/mozillians-tests",
     "https://github.com/mozilla-services/services-test",
     "https://github.com/mozilla/stubattribution-tests"
-  ],
-  "api_token": "692aadd2c9789a337c4d3544787f101ad8c35bc7"
+  ]
 }

--- a/js/aggregator.js
+++ b/js/aggregator.js
@@ -15,7 +15,7 @@ function GithubIssuesAggregator(){
             }
 
             var base_url = 'https://api.github.com/repos/';
-            var url_suffix = '/issues?per_page=100&state=open&sort=created&access_token=' + config_data.api_token;
+            var url_suffix = '/issues?per_page=100&state=open&sort=created';
 
             for(i = 0; i < repos.length; i++){
                 (function(index){


### PR DESCRIPTION
I suspect this was added for rate-limiting, but we shouldn't expose tokens, even if they are read-only.